### PR TITLE
feat: allow setting query params for opening sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const preview: Preview = {
       /**
        * @optional
        * Pass custom files/modules into the sandbox. These files
-       * will be added to the file system of the sandbox and can 
+       * will be added to the file system of the sandbox and can
        * be imported by other files
        */
       files: {
@@ -63,14 +63,14 @@ const preview: Preview = {
         "index.js": `
 export const foo = () => console.log("Hello World");`
         "App.js": `
-import { foo } from "./index.js"; 
+import { foo } from "./index.js";
 
 foo();`,
       },
 
       /**
        * @optional
-       * Template preset to be used in the sandbox. This will 
+       * Template preset to be used in the sandbox. This will
        * determine the initial setup of the sandbox, such as
        * bundler, dependencies, and files.
        */
@@ -78,8 +78,8 @@ foo();`,
 
       /**
        * @optional
-       * Dependencies list to be installed in the sandbox. 
-       * 
+       * Dependencies list to be installed in the sandbox.
+       *
        * @note You cannot use local modules or packages since
        * this story runs in an isolated environment (sandbox)
        * inside CodeSandbox. As such, the sandbox doesn't have
@@ -130,6 +130,14 @@ foo();`,
             </Theme>
           )
         }`,
+
+      /**
+       * @optional
+       * Query parameters to be passed to the sandbox url that is opened.
+       */
+      queryParams: {
+        "file": "/src/App.js",
+      },
     },
   },
 };
@@ -197,4 +205,3 @@ For now, this addon only support [Component Story Format (CSF)](Component Story 
 
 - Ensure that you have proper permissions and access rights to the CodeSandbox workspace specified in the configuration.
 - Verify the correctness of the dependencies and providers listed in the configuration to ensure the sandbox runs smoothly.
-

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "github.com"
   },
+  "packageManager": "pnpm@9.15.0",
   "type": "module",
   "license": "Apache-2.0",
   "author": "CodeSandbox <danilo@codesandbox.io>",

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -18,6 +18,7 @@ export type CSBParameters =
       sandboxId: string;
       files: Record<string, string>;
       template?: "react" | "angular";
+      queryParams?: Record<string, string>;
     }
   | undefined;
 
@@ -54,6 +55,7 @@ export const CodeSandboxTool = memo(function MyAddonSelector({
     files: codesandboxParameters?.files ?? {},
     apiToken: codesandboxParameters?.apiToken,
     sandboxId: codesandboxParameters?.sandboxId,
+    queryParams: codesandboxParameters?.queryParams ?? {},
   };
 
   async function createSandbox() {
@@ -125,10 +127,16 @@ export const CodeSandboxTool = memo(function MyAddonSelector({
 
       const data: { data: { alias: string } } = await response.json();
 
-      window.open(
-        `https://codesandbox.io/p/sandbox/${data.data.alias}?file=/src/App.js&utm-source=storybook-addon`,
-        "_blank",
+      const csbUrl = new URL(
+        `https://codesandbox.io/p/sandbox/${data.data.alias}`,
       );
+      for (const [key, value] of Object.entries(options.queryParams)) {
+        csbUrl.searchParams.set(key, value);
+      }
+      csbUrl.searchParams.set("file", "/src/App.js");
+      csbUrl.searchParams.set("utm-source", "storybook-addon");
+
+      window.open(csbUrl.toString(), "_blank");
 
       setLoading(false);
     } catch (error) {

--- a/src/Tool.tsx
+++ b/src/Tool.tsx
@@ -130,10 +130,10 @@ export const CodeSandboxTool = memo(function MyAddonSelector({
       const csbUrl = new URL(
         `https://codesandbox.io/p/sandbox/${data.data.alias}`,
       );
+      csbUrl.searchParams.set("file", "/src/App.js");
       for (const [key, value] of Object.entries(options.queryParams)) {
         csbUrl.searchParams.set(key, value);
       }
-      csbUrl.searchParams.set("file", "/src/App.js");
       csbUrl.searchParams.set("utm-source", "storybook-addon");
 
       window.open(csbUrl.toString(), "_blank");


### PR DESCRIPTION
You can now set query parameters as follows:

```
parameters: {
  codesandbox: {
    apiToken: '...',
    template: 'react',
    privacy: 'private',
    sandboxId: 'abcde',
    queryParams: { file: '/src/App.js' } 
  }
}
```